### PR TITLE
Add REACT_APP envs to frontend docker build

### DIFF
--- a/.github/workflows/master_push.yml
+++ b/.github/workflows/master_push.yml
@@ -58,6 +58,10 @@ jobs:
         docker build -t frontend .
         docker tag frontend ${{secrets.DOCKER_USERNAME}}/adminapp-medified-frontend:latest
         docker push ${{secrets.DOCKER_USERNAME}}/adminapp-medified-frontend:latest
+      env:
+        REACT_APP_USER_POOL_ID: ${{ secrets.REACT_APP_USER_POOL_ID }}
+        REACT_APP_WEB_CLIENT_ID: ${{ secrets.REACT_APP_WEB_CLIENT_ID }}
+        REACT_APP_AUTHENTICATION_TYPE: ${{ secrets.REACT_APP_AUTHENTICATION_TYPE }}
 
     - name: Dockerhub backend deploy latest
       run: |


### PR DESCRIPTION
Hotfix for adding REACT_APP envs to github actions part where frontend image is built. Because frontend is going to be static build it can't read envs from staging/production.