### PR TITLE
Change the order of instructions in Dockerfiles

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -2,17 +2,17 @@ FROM node:14.15-alpine
 
 WORKDIR /usr/src/app
 
-RUN chown -R node:node /usr/src/app
-USER node
-
 COPY package.json .
 COPY package-lock.json .
+
+RUN npm ci
 
 ARG NODE_ENV=production
 ENV NODE_ENV=${NODE_ENV}
 
-RUN npm ci
-
 COPY . .
+
+RUN chown -R node:node /usr/src/app
+USER node
 
 CMD npm start

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -2,17 +2,15 @@ FROM node:14.15-alpine
 
 WORKDIR /usr/src/app
 
-RUN chown -R node:node /usr/src/app
-
 COPY package.json .
 COPY package-lock.json .
+
+RUN npm ci
 
 ARG NODE_ENV=production
 ENV NODE_ENV=${NODE_ENV}
 # ARG API_URL
 # ENV API_URL=${API_URL}
-
-RUN npm ci
 
 COPY . .
 
@@ -20,6 +18,8 @@ RUN if [ "${NODE_ENV}" != "development" ]; then \
     npm run build && \
     npm install -g serve; \
     fi
+
+RUN chown -R node:node /usr/src/app
 
 USER node
 


### PR DESCRIPTION
Need to research more for a better way of handling this. Now we are
installing all devDependencies for making production build, which is
wasteful.