### PR TITLE
Edit script to exit on error

### DIFF
--- a/lintCommit.sh
+++ b/lintCommit.sh
@@ -1,3 +1,4 @@
+set -e;
 cd frontend;
 npm run lint-fix;
 cd ../backend;


### PR DESCRIPTION
This edits lintCommit.sh to exit if eslint detects an error so that commits with errors wont be made.