### PR TITLE
Fix backend middleware continuing after error

### DIFF
--- a/backend/utils/middleware.js
+++ b/backend/utils/middleware.js
@@ -56,6 +56,7 @@ const authenticateToken = (req, res, next) => {
 
     if (bearer === undefined || bearer.indexOf('Bearer ') !== 0) {
       res.status(403).send({ error: 'Invalid token!' })
+      return
     }
     const idTokenFromClient = bearer !== undefined
       ? bearer.substr('Bearer '.length)


### PR DESCRIPTION
Backend was throwing 'Can't set headers after they are sent to the client' caused by 'middleware.js'. Returning after failing token check seems to fix this.