### PR TITLE
Update install script to use npm ci

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -3,13 +3,13 @@
 install_local_npm_packages () {
     cd ./frontend
     echo $PWD
-    npm install
+    npm ci
     cd ../backend
     echo $PWD
-    npm install
+    npm ci
     cd ..
     echo $PWD
-    npm install
+    npm ci
 }
 
 echo "Install local npm packages"


### PR DESCRIPTION
Using npm ci is giving more consistent results than npm install. It
removes node_modules and installs dependencies with package-lock.json.