### PR TITLE
Remove console.logs from frontend

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -109,7 +109,7 @@ const App = () => {
         )
         return refreshedUser
       } catch (error) {
-        console.log('error refreshing token', error)
+        return
       }
     }
 
@@ -118,7 +118,7 @@ const App = () => {
         const pingStatus = await dataService.getAll('ping')
         return pingStatus
       } catch (error) {
-        console.log('secure ping error', error)
+        return
       }
     }
 
@@ -127,7 +127,7 @@ const App = () => {
         await loginService.logOut()
         setUser(undefined)
       } catch (exception) {
-        console.log('An error occured')
+        return
       }
     }
 

--- a/frontend/src/components/LoginForm.js
+++ b/frontend/src/components/LoginForm.js
@@ -60,7 +60,7 @@ const LoginForm = ({ username, setUsername, password, setPassword, user, setUser
       setUsername('')
       setPassword('')
     } catch (exception) {
-      console.log(exception)
+      return
     }
   }
 

--- a/frontend/src/components/uiComponents/AppTopbar.js
+++ b/frontend/src/components/uiComponents/AppTopbar.js
@@ -23,7 +23,7 @@ const AppTopbar = ({ user, setUser }) => {
       await loginService.logOut()
       setUser(undefined)
     } catch (exception) {
-      console.log('An error occured')
+      return
     }
   }
 

--- a/frontend/src/services/dataService.js
+++ b/frontend/src/services/dataService.js
@@ -52,11 +52,9 @@ const getAll = async (endpoint) => {
     const response = await axios.get(endpoint, getConfig())
     return response.data
   } catch (error) {
-    console.log(error.message)
     if(error.message.includes('403')) {
       return 403
     }
-    console.log(error)
     return []
   }
 }

--- a/frontend/src/services/loginService.js
+++ b/frontend/src/services/loginService.js
@@ -20,14 +20,11 @@ import { Auth } from 'aws-amplify'
  * @returns {*} - Logged user details
  */
 const login = async credentials => {
-  console.log(credentials.username)
-  console.log(credentials.password)
-  console.log(Auth.configure())
   let user
   try {
     user = await Auth.signIn(credentials.username, credentials.password)
   } catch (error) {
-    console.log('error signing in', error)
+    return []
   }
   return {
     user
@@ -48,7 +45,7 @@ const logOut = async () => {
     Auth.signOut()
     window.localStorage.clear()
   } catch (error) {
-    console.log('error signing out', error)
+    return
   }
 }
 


### PR DESCRIPTION
Changed console.logs to be empty return statements. Preparing for making production ready build.

(This is probably not the best way to handle errors, but hopefully okay for now.)