### PR TITLE
Added backend tests for filtering

### DIFF
--- a/backend/controllers/controller.js
+++ b/backend/controllers/controller.js
@@ -22,8 +22,6 @@ const user_care_giver_activities = db.user_care_giver_activities
 const { Sequelize } = require('../models')
 const Op = Sequelize.Op
 
-const sequelize = db.sequelize
-
 
 /**
  * Returns all access codes from database
@@ -32,9 +30,9 @@ const sequelize = db.sequelize
  */
 
 const findAllAccessCodes = async (organisation) => {
-  console.log(access_codes)
+
   let accessCodes = undefined
-  if(organisation === 'undefined') {
+  if (organisation === 'undefined') {
     accessCodes = await access_codes.findAll({
       attributes: ['id', 'user_id', 'organisation_id', 'created_at', 'updated_at']
     })
@@ -46,7 +44,6 @@ const findAllAccessCodes = async (organisation) => {
       }
     })
   }
-
   return accessCodes
 }
 
@@ -74,10 +71,21 @@ const findAllOrgs = async (organisation) => {
 
 const findAllUsers = async (organisation, withCaregiver) => {
   let userProfiles
-  if(organisation === 'undefined') {
+  if (organisation === 'undefined') {
     // admin request from all data
     if (withCaregiver === true) {
-      userProfiles = sequelize.query('SELECT DISTINCT user_profiles.user_id, user_profiles.created_at, user_profiles.first_name, user_profiles.last_name, user_profiles.updated_at, user_profiles.added_organisation FROM user_profiles, user_care_givers WHERE user_profiles.user_id = user_care_givers.user_id', { type: sequelize.QueryTypes.SELECT })
+      const caregivers = await user_care_givers.findAll()
+      const userIdsLinkedToCaregivers = caregivers.map(relationship => relationship.user_id)
+      console.log('VOITKO TULOSTAA TÄN')
+      console.log(userIdsLinkedToCaregivers)
+      let uniqueIds = [...new Set(userIdsLinkedToCaregivers)]
+
+      userProfiles = await user_profiles.findAll({
+        attributes: ['user_id', 'created_at', 'first_name', 'last_name', 'updated_at', 'added_organisation'],
+        where: {
+          userId: uniqueIds
+        }
+      })
     } else {
       userProfiles = await user_profiles.findAll({
         attributes: ['user_id', 'created_at', 'first_name', 'last_name', 'updated_at', 'added_organisation']
@@ -96,7 +104,7 @@ const findAllUsers = async (organisation, withCaregiver) => {
     const userIdsLinkedToOrganisationalCaregivers = caregiverUserRelationshipsOrganisation.map(relationship => relationship.user_id)
     let uniqueIds = [...new Set(userIdsLinkedToOrganisationalCaregivers)]
 
-    if(withCaregiver === true) {
+    if (withCaregiver === true) {
       userProfiles = await user_profiles.findAll({
         attributes: ['user_id', 'created_at', 'first_name', 'last_name', 'updated_at', 'added_organisation'],
         where: {

--- a/backend/tests/controller.test.js
+++ b/backend/tests/controller.test.js
@@ -22,6 +22,16 @@ describe('user_profiles', () => {
     expect(users.length).toEqual(1)
     expect(users[0].first_name).toEqual('Mikko')
   })
+
+  it('are returned correctly by organisation', async () => {
+    const users = await controller.findAllUsers('OHTU')
+    expect(users.length).toEqual(1)
+  })
+
+  it('are returned correctly with organisation and cargiver filtering', async () => {
+    const users = await controller.findAllUsers('OHTU', true)
+    expect(users.length).toEqual(1)
+  })
 })
 
 jest.mock('../models/organisations', () => () => {
@@ -45,6 +55,11 @@ describe('organisations', () => {
     expect(orgs.length).toEqual(1)
     expect(orgs[0].id).toEqual('OHTU')
   })
+
+  it('are not returned if request is sent without admin access', async () => {
+    const orgs = await controller.findAllOrgs('OLEMATON')
+    expect(orgs).toBe(null)
+  })
 })
 
 jest.mock('../models/access_codes', () => () => {
@@ -53,15 +68,22 @@ jest.mock('../models/access_codes', () => () => {
 
   return dbMock.define('access_codes', {
     id: '45h743ffd',
-    user_id: '1a2b3c'
+    user_id: '1a2b3c',
+    organisation_id: 'OHTU'
   })
 })
 
 describe('access_codes', () => {
-  it('can be found from database', async () => {
-    const codes = await controller.findAllAccessCodes()
-    expect(codes.length).toEqual(1)
-    expect(codes[0].id).toEqual('45h743ffd')
+  it('are all returned if organisation is undefined', async () => {
+    const accessCodes = await controller.findAllAccessCodes('undefined')
+    expect(accessCodes.length).toEqual(1)
+    expect(accessCodes[0].id).toEqual('45h743ffd')
+  })
+
+  it('are returned correctly with defined organisation', async () => {
+    const accessCodes = await controller.findAllAccessCodes('OHTU')
+    expect(accessCodes.length).toEqual(1)
+    expect(accessCodes[0].organisation_id).toEqual('OHTU')
   })
 })
 

--- a/backend/tests/usersWithCaregiver.test.js
+++ b/backend/tests/usersWithCaregiver.test.js
@@ -1,0 +1,55 @@
+const sinon = require('sinon')
+let controller, mockedController, db, user_profiles_stub
+
+const controllerMocked = () => {
+  db = require('../models')
+
+  user_profiles_stub = sinon.stub(db.user_profiles, 'findAll')
+    .callsFake(() => {
+      return [
+        {
+          dataValues: {
+            user_id: '1a2b3c',
+            height: null,
+            weight: null,
+            sex: null,
+            birth_date: null,
+            first_name: 'Mikko',
+            last_name: 'Mallikas',
+            added_organisation: 'OHTU'
+          }
+        }
+      ]
+    })
+  controller = require('../controllers/controller')
+  return controller
+}
+
+jest.mock('../models/user_care_givers', () => () => {
+  const SequelizeMock = require('sequelize-mock')
+  const dbMock = new SequelizeMock()
+
+  return dbMock.define('user_care_givers', {
+    id: 16,
+    user_id: 'fdd8sklla',
+    access_code_id: 'hfd465m45',
+    consent: true
+  })
+})
+
+
+describe('users with caregivers', () => {
+  beforeEach(() => {
+    mockedController = controllerMocked()
+  })
+
+  test('are returned correctly', async () => {
+    const users = await mockedController.findAllUsers('undefined', true)
+    console.log(users)
+    expect(users.length).toEqual(1)
+  })
+
+  afterEach(() => {
+    user_profiles_stub.restore()
+  })
+})


### PR DESCRIPTION
Backend tests now cover filtering based on organisation and whether app user has caregiver. Filtering based on caregiver is also modified to use sequelize instead of raw SQL.