### PR TITLE
Remove error logs from frontend tests

### DIFF
--- a/frontend/src/components/Filter.test.js
+++ b/frontend/src/components/Filter.test.js
@@ -66,10 +66,12 @@ describe('<Filter />', () => {
    * @param {string} description - eventhandler is called once
    * @param {object} TestCode - code that runs the test
    */
-  test('checking filtering checkbox calls event handler once', async() => {
+  test('checking filtering checkbox calls event handler once', async () => {
     const checkbox = component.getByTestId('filter-checkbox')
     fireEvent.click(checkbox)
 
-    expect(mockHandler.mock.calls).toHaveLength(1)
+    waitFor(() => {
+      expect(mockHandler.mock.calls).toHaveLength(1)
+    })
   })
 })


### PR DESCRIPTION
This attempts to remove error logs from frontend tests.
Auth error is removed in other pr

### Todo
- [ ] Remove overlapping act calls error
- [ ] Remove cannot log after tests are done
- [ ] Failed to create chart