### PR TITLE
Fix caregiver filter in weekly improvement backend

### DIFF
--- a/backend/controllers/improvementController.js
+++ b/backend/controllers/improvementController.js
@@ -226,7 +226,7 @@ const findWeeklyMoods = async (userMoodsData) => {
   return valuesWeekly
 }
 
-/**
+/**.
  * Find weekly mood improvement percentages
  *
  * @constant

--- a/backend/routes/routes.js
+++ b/backend/routes/routes.js
@@ -40,7 +40,7 @@ router.get('/weeklyvalues', async (req, res) => {
   res.json(weeklyvalues)
 })
 
-/**
+/**.
  * Route request for weekly mood improvement
  *
  * @name get_weeklyimprovement
@@ -50,7 +50,8 @@ router.get('/weeklyvalues', async (req, res) => {
  * @param {object} middleware - Handle request to path
  */
 router.get('/weeklyimprovement', async (req, res) => {
-  const weeklyImprovement = await improvementController.findWeeklyImprovement(req.query.organisation, req.query.withCaregiver,
+  const withCaregiver = req.query.withcaregiver === 'true'
+  const weeklyImprovement = await improvementController.findWeeklyImprovement(req.query.organisation, withCaregiver,
     req.query.startDate, req.query.endDate, req.query.variable)
   res.json(weeklyImprovement)
 })

--- a/cypress/integration/moodAverageWeekly.test.js
+++ b/cypress/integration/moodAverageWeekly.test.js
@@ -1,11 +1,11 @@
-/**
+/**.
  * Cypress tests for MoodAverage chart
  *
  * @module cypress/integration/moodAverage_spec
  * @requires cypress
  */
 
-/**
+/**.
  * Describe tests for mood average page
  *
  * @name MoodAverage
@@ -16,7 +16,7 @@
  */
 describe('MoodAverage chart', function () {
 
-  /**
+  /**.
    * Log in fast before each test
    *
    * @name beforeEach
@@ -29,7 +29,7 @@ describe('MoodAverage chart', function () {
     cy.login()
   })
 
-  /**
+  /**.
    * Log out fast after each test
    *
    * @name afterEach
@@ -42,7 +42,7 @@ describe('MoodAverage chart', function () {
     cy.logOut()
   })
 
-  /**
+  /**.
    * Test that mood average page exists
    *
    * @name MoodAverage_exists

--- a/frontend/src/components/AverageMoodWeekly.test.js
+++ b/frontend/src/components/AverageMoodWeekly.test.js
@@ -1,4 +1,4 @@
-/**
+/**.
  * Tests for AverageMoodWeekly component
  *
  * @module src/components/AverageMoodWeekly_test
@@ -12,7 +12,7 @@ import '@testing-library/jest-dom/extend-expect'
 import { render, waitFor } from '@testing-library/react'
 import AverageMoodWeekly from './AverageMoodWeekly'
 
-/**
+/**.
  * Describe tests
  *
  * @type {object}
@@ -24,7 +24,7 @@ import AverageMoodWeekly from './AverageMoodWeekly'
 describe('<AverageMoodWeekly />', () => {
   let component
 
-  /**
+  /**.
    * Render AverageMoodWeekly
    *
    * @type {object}
@@ -37,7 +37,7 @@ describe('<AverageMoodWeekly />', () => {
     component = render(<AverageMoodWeekly />)
   })
 
-  /**
+  /**.
    * Test that MoodAverage is rendered
    *
    * @type {object}

--- a/frontend/src/components/WeeklyImprovement.test.js
+++ b/frontend/src/components/WeeklyImprovement.test.js
@@ -1,4 +1,4 @@
-/**
+/**.
  * Tests for WeeklyImprovement component
  *
  * @module src/components/WeeklyImprovement_test
@@ -12,7 +12,7 @@ import '@testing-library/jest-dom/extend-expect'
 import { render, waitFor } from '@testing-library/react'
 import WeeklyImprovement from './WeeklyImprovement'
 
-/**
+/**.
  * Describe tests
  *
  * @type {object}
@@ -24,7 +24,7 @@ import WeeklyImprovement from './WeeklyImprovement'
 describe('<WeeklyImprovement />', () => {
   let component
 
-  /**
+  /**.
    * Render WeeklyImprovement
    *
    * @type {object}
@@ -37,7 +37,7 @@ describe('<WeeklyImprovement />', () => {
     component = render(<WeeklyImprovement />)
   })
 
-  /**
+  /**.
    * Test that WeeklyImprovement is rendered
    *
    * @type {object}


### PR DESCRIPTION
This PR has a backend fix in weekly improvement graph: now when caregiver filter is chosen in frontend, the filter is affected in the weekly improvement graph as well.