### PR TITLE
Sort retention rate 

### DIFF
--- a/cypress/integration/retentionRate.spec.js
+++ b/cypress/integration/retentionRate.spec.js
@@ -55,8 +55,8 @@ describe('Retention rate', function () {
   it('exists', function () {
     cy.contains('Adminapp for monitoring moods')
     cy.contains('Retention rates')
-    cy.contains('Average using period 17.83 days')
-    cy.contains('Average period and single periods:')
+    cy.contains('Average using period is 17.83 days')
+    cy.contains('Single periods:')
   })
 
   /**.
@@ -74,8 +74,8 @@ describe('Retention rate', function () {
     cy.get('[data-testid="filter-checkbox"]').check()
     cy.contains('Adminapp for monitoring moods')
     cy.contains('Retention rates')
-    cy.contains('Average using period 33.00 days')
-    cy.contains('Average period and single periods:')
+    cy.contains('Average using period is 33.00 days')
+    cy.contains('Single periods:')
   })
 
   /**.
@@ -93,8 +93,8 @@ describe('Retention rate', function () {
     cy.get('[data-testid="startDate-checkbox"]').check()
     cy.get('[data-testid="startDate-date"]').type('2020-10-01')
     cy.contains('Retention rates')
-    cy.contains('Average using period 17.33 days')
-    cy.contains('Average period and single periods:')
+    cy.contains('Average using period is 17.33 days')
+    cy.contains('Single periods:')
   })
 
   /**.
@@ -112,8 +112,8 @@ describe('Retention rate', function () {
     cy.get('[data-testid="endDate-checkbox"]').check()
     cy.get('[data-testid="endDate-date"]').type('2020-11-01')
     cy.contains('Retention rates')
-    cy.contains('Average using period 2.00 days')
-    cy.contains('Average period and single periods:')
+    cy.contains('Average using period is 2.00 days')
+    cy.contains('Single periods:')
   })
 
   /**.
@@ -133,8 +133,8 @@ describe('Retention rate', function () {
     cy.get('[data-testid="endDate-checkbox"]').check()
     cy.get('[data-testid="endDate-date"]').type('2020-12-01')
     cy.contains('Retention rates')
-    cy.contains('Average using period 2.50 days')
-    cy.contains('Average period and single periods:')
+    cy.contains('Average using period is 2.50 days')
+    cy.contains('Single periods:')
   })
 
   /**.
@@ -149,15 +149,15 @@ describe('Retention rate', function () {
    */
   it('exists after checking only patients with caregivers, start date and end date in filters', function () {
     cy.contains('Retention rates')
-    cy.contains('Average using period 17.83 days')
-    cy.contains('Average period and single periods:')
+    cy.contains('Average using period is 17.83 days')
+    cy.contains('Single periods:')
     cy.contains('Filter').click()
     cy.get('[data-testid="filter-checkbox"]').check()
     cy.get('[data-testid="startDate-checkbox"]').check()
     cy.get('[data-testid="startDate-date"]').type('2020-06-01')
     cy.get('[data-testid="endDate-checkbox"]').check()
     cy.get('[data-testid="endDate-date"]').type('2021-02-01')
-    cy.contains('Average using period 46.50 days')
-    cy.contains('Average period and single periods:')
+    cy.contains('Average using period is 46.50 days')
+    cy.contains('Single periods:')
   })
 })

--- a/frontend/src/components/RetentionRate.js
+++ b/frontend/src/components/RetentionRate.js
@@ -21,17 +21,15 @@ import { Chart } from 'primereact/chart'
 const RetentionRate = ({ retentionRates, average }) => {
 
   const daysUsed = retentionRates.map(obj => obj.daysUsed)
-
   daysUsed.sort((a,b) => a - b)
   daysUsed.reverse()
 
-  const data = [average, ...daysUsed]
+  const data = [...daysUsed]
 
   let labels = []
   for (let days of daysUsed) {
     labels = [...labels, days]
   }
-  labels = ['Average', ...labels]
 
   const barChart = {
     labels: labels,
@@ -61,6 +59,7 @@ const RetentionRate = ({ retentionRates, average }) => {
         ticks: {
           min: 0,
           max: 100,
+          separator: 50,
           fontColor: '#454545'
         }
       }]
@@ -87,6 +86,7 @@ const RetentionRate = ({ retentionRates, average }) => {
           <p> Average using period {parseFloat(average).toFixed(2)} days</p>
           <p> Average period and single periods:</p>
           <Chart type="bar" data={barChart} options={options}></Chart>
+
         </div>
       </div>
     </div>

--- a/frontend/src/components/RetentionRate.js
+++ b/frontend/src/components/RetentionRate.js
@@ -58,7 +58,7 @@ const RetentionRate = ({ retentionRates, average }) => {
       yAxes: [{
         ticks: {
           min: 0,
-          max: 150,
+          max: 160,
           fontColor: '#454545'
         }
       }]

--- a/frontend/src/components/RetentionRate.js
+++ b/frontend/src/components/RetentionRate.js
@@ -58,8 +58,7 @@ const RetentionRate = ({ retentionRates, average }) => {
       yAxes: [{
         ticks: {
           min: 0,
-          max: 100,
-          separator: 50,
+          max: 150,
           fontColor: '#454545'
         }
       }]

--- a/frontend/src/components/RetentionRate.js
+++ b/frontend/src/components/RetentionRate.js
@@ -21,6 +21,10 @@ import { Chart } from 'primereact/chart'
 const RetentionRate = ({ retentionRates, average }) => {
 
   const daysUsed = retentionRates.map(obj => obj.daysUsed)
+
+  daysUsed.sort((a,b) => a - b)
+  daysUsed.reverse()
+
   const data = [average, ...daysUsed]
 
   let labels = []

--- a/frontend/src/components/RetentionRate.js
+++ b/frontend/src/components/RetentionRate.js
@@ -83,8 +83,8 @@ const RetentionRate = ({ retentionRates, average }) => {
       <div className="p-shadow-1" style={containerStyle}>
         <div className="card" style={cardStyle}>
           <h3>Retention rates</h3>
-          <p> Average using period {parseFloat(average).toFixed(2)} days</p>
-          <p> Average period and single periods:</p>
+          <p> Average using period is {parseFloat(average).toFixed(2)} days</p>
+          <p> Single periods:</p>
           <Chart type="bar" data={barChart} options={options}></Chart>
 
         </div>

--- a/frontend/src/components/RetentionRate.test.js
+++ b/frontend/src/components/RetentionRate.test.js
@@ -53,7 +53,7 @@ describe('<RetentionRate />', () => {
    */
   test('renders RetentionRate', () => {
     expect(component.container).toHaveTextContent('Retention rates')
-    expect(component.container).toHaveTextContent('Average using period')
-    expect(component.container).toHaveTextContent('Average period and single periods:')
+    expect(component.container).toHaveTextContent('Average using period is')
+    expect(component.container).toHaveTextContent('Single periods:')
   })
 })


### PR DESCRIPTION
The retention rate graph is now sorted in descending order. 

The idea was to add the average as a horizontal line as well, but I couldn't find a good solution for it. The closest thing I could find was a combo chart but I think it would have been more confusing than informative (https://www.primefaces.org/primereact/showcase/#/combochart). Now the average bar has been removed, and the average is presented just as a numeric value like before.