### PR TITLE
Remove unnecessary grids

### DIFF
--- a/frontend/src/components/AverageMoodWeekly.js
+++ b/frontend/src/components/AverageMoodWeekly.js
@@ -56,6 +56,13 @@ const AverageMoodWeekly = ({ moodAverages, byPeriod }) => {
     console.log(moodChartData)
 
     chartOptions = {
+      scales: {
+        xAxes: [{
+          gridLines: {
+            color: '#ffffff',
+          }
+        }]
+      }
     }
   } else {
     moodChartData = {
@@ -68,6 +75,9 @@ const AverageMoodWeekly = ({ moodAverages, byPeriod }) => {
       scales: {
         xAxes: [{
           type: 'time',
+          gridLines: {
+            color: '#ffffff',
+          }
         }]
       }
     }

--- a/frontend/src/components/RetentionRate.js
+++ b/frontend/src/components/RetentionRate.js
@@ -57,13 +57,6 @@ const RetentionRate = ({ retentionRates, average }) => {
         gridLines: {
           color: '#ffffff',
         }
-      }],
-      yAxes: [{
-        ticks: {
-          min: 0,
-          max: 160,
-          fontColor: '#454545'
-        }
       }]
     }
   }

--- a/frontend/src/components/RetentionRate.js
+++ b/frontend/src/components/RetentionRate.js
@@ -54,6 +54,9 @@ const RetentionRate = ({ retentionRates, average }) => {
           fontColor: '#454545'
         },
         width: '10px',
+        gridLines: {
+          color: '#ffffff',
+        }
       }],
       yAxes: [{
         ticks: {

--- a/frontend/src/components/TotalMoodImprovement.js
+++ b/frontend/src/components/TotalMoodImprovement.js
@@ -46,7 +46,15 @@ const TotalImprovement = ({ totalImprovementAverages, byPeriod }) => {
         : labelText,
       datasets: [totalImprovementDataset]
     }
-    chartOptions = {}
+    chartOptions = {
+      scales: {
+        xAxes: [{
+          gridLines: {
+            color: '#ffffff',
+          }
+        }]
+      }
+    }
   } else {
     moodChartData = {
       labels: totalImprovementAverages === undefined || totalImprovementAverages === null ? []
@@ -58,6 +66,9 @@ const TotalImprovement = ({ totalImprovementAverages, byPeriod }) => {
       scales: {
         xAxes: [{
           type: 'time',
+          gridLines: {
+            color: '#ffffff',
+          }
         }]
       }
     }

--- a/frontend/src/components/WeeklyImprovement.js
+++ b/frontend/src/components/WeeklyImprovement.js
@@ -44,7 +44,15 @@ const WeeklyImprovement = ({ weeklyImprovementAverages, byPeriod }) => {
         : labelText,
       datasets: [weeklyImprovementDataset]
     }
-    chartOptions = {}
+    chartOptions = {
+      scales: {
+        xAxes: [{
+          gridLines: {
+            color: '#ffffff',
+          }
+        }]
+      }
+    }
   } else {
     moodChartData = {
       labels: weeklyImprovementAverages === undefined || weeklyImprovementAverages === null ? []
@@ -56,6 +64,9 @@ const WeeklyImprovement = ({ weeklyImprovementAverages, byPeriod }) => {
       scales: {
         xAxes: [{
           type: 'time',
+          gridLines: {
+            color: '#ffffff',
+          }
         }]
       }
     }


### PR DESCRIPTION
- Removed grids on x-scale from other than the first graph
- y-scale in retention rate now adjusts according to filtered data (earlier it was fixed to 160)

<img width="898" alt="Screen Shot 2021-05-04 at 10 25 27" src="https://user-images.githubusercontent.com/28861660/116972042-22f4c980-acc3-11eb-8af7-6ebaa18847d7.png">
