### PR TITLE
Reduce unnecessary chart rendering

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -60,7 +60,6 @@ const App = () => {
   const [username, setUsername] = useState('')
   const [password, setPassword] = useState('')
   const [organisationSelect, setOrganisation] = useState('ALL')
-  const [visible, setVisible] = useState(false)
   const [organisations, setOrganisations] = useState([])
   const [startDateEnable, setStartDateEnable] = useState(false)
   const [endDateEnable, setEndDateEnable] = useState(false)
@@ -349,8 +348,6 @@ const App = () => {
                 caregiverFilterForAllUsers={caregiverFilterForAllUsers}
                 handleFilterChange={handleFilterChange}
                 organisations={organisations}
-                visible={visible}
-                setVisible={setVisible}
                 organisationSelect={organisationSelect}
                 handleOrganisationChange={handleOrganisationChange}
                 startDateEnable={startDateEnable}

--- a/frontend/src/components/uiComponents/AppTopbar.js
+++ b/frontend/src/components/uiComponents/AppTopbar.js
@@ -12,7 +12,7 @@
  * @requires frontend/src/components/Organisations
  * @exports AppTopbar - Page topbar
  */
-import React from 'react'
+import React, { useState } from 'react'
 import { Toolbar } from 'primereact/toolbar'
 import { Button } from 'primereact/button'
 import { Sidebar } from 'primereact/sidebar'
@@ -32,10 +32,12 @@ import Header from './AppHeader'
  * @returns {object} - JSX Topbar component
  */
 const AppTopbar = ({ user, setUser, caregiverFilterForAllUsers, handleFilterChange,
-  visible, setVisible, organisations, handleOrganisationChange, organisationSelect,
+  organisations, handleOrganisationChange, organisationSelect,
   startDateEnable, endDateEnable, startDate, endDate, handleStartDateEnableChange,
   handleEndDateEnableChange, handleStartDateChange, handleEndDateChange,
   moodDataSelect, moodGraphLabels, handleMoodDataSelectChange }) => {
+
+  const [visible, setVisible] = useState(false)
 
   /**.
    * Handle logout button presses


### PR DESCRIPTION
Moved filter sidebar state from App to AppTopbar. This reduces re-rendering when sidebar is shown/hidden.

Tried also other things but didn't find any easy ways to accomplish this.